### PR TITLE
added fix for vertical tabs/labels

### DIFF
--- a/skin/tabs.less
+++ b/skin/tabs.less
@@ -46,3 +46,9 @@ ko-pane[type="icons"] tab
     margin-right: 0;
   }
 }
+
+ko-pane .tabs-vertical-label {
+	-moz-appearance: none;
+	background: -moz-linear-gradient(center top , rgba(39, 40, 42, 0.1) 15%, rgba(0, 0, 0, 0.2) 100%);
+	padding-left: 4px;
+}


### PR DESCRIPTION
added a fix for the vertical labels, -moz-appearance: none removed the ugly gradient, the padding left is added to not stick to the left side and the gradient is added so it becomes more a header than just floating text (gradient is the same as the one on the horizontal tabs to be consistent with the color scheme).

Before:
![snap 2015-07-25 at 14 16 10](https://cloud.githubusercontent.com/assets/3530262/8889364/f724f066-32d7-11e5-93ec-6044528f7448.png)

and after:
![snap 2015-07-25 at 14 17 17](https://cloud.githubusercontent.com/assets/3530262/8889365/02b917f4-32d8-11e5-9985-52c65c83e197.png)
